### PR TITLE
Update API for retrieving theme in monaco-editor version 0.21.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wire `monaco-textmate` with `monaco-editor`
 
+**Note:** *The latest version of this library requires `monaco-editor` version `0.21.2` and up. If you wish to use an older version of `monaco-editor` `0.19.x` or below, you should use an older version `2.2.2` of this library.*
+
 ## Install
 
 ```sh

--- a/src/tm-to-monaco-token.ts
+++ b/src/tm-to-monaco-token.ts
@@ -37,12 +37,12 @@ export const TMToMonacoToken = (editor: monacoNsps.editor.ICodeEditor, scopes: s
             if (char === ".") {
                 const token = scope.slice(0, i);
                 if (
-                    editor['_themeService'].getTheme()._tokenTheme._match(token + "." + scopeName)._foreground >
+                    editor['_themeService']._theme._tokenTheme._match(token + "." + scopeName)._foreground >
                     1
                 ) {
                     return token + "." + scopeName;
                 }
-                if (editor['_themeService'].getTheme()._tokenTheme._match(token)._foreground > 1) {
+                if (editor['_themeService']._theme._tokenTheme._match(token)._foreground > 1) {
                     return token;
                 }
             }


### PR DESCRIPTION
The new API is: editor._themeService._theme instead of editor._themeService.getTheme()